### PR TITLE
Fix deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-# dpline
+# Dpline
 
 Delivery Pipeline
 
 
 ## Installation
+
+Latest version
+
+virtualenv ~/dpline_venv && source ~/dpline_venv/bin/activate
+pip install .
+
+Stable version:
 
 pip install python-dpline
 
@@ -11,17 +18,14 @@ pip install python-dpline
 
 Deploy Dpline delivery pipeline:
 
-    dpline deploy --all
+    ./deploy_dpline.sh
 
 
 ## Access
 
 A summary of how to access the different services deployed by Dpline
 
-
-To access Prometheus, got to http://localhost:9090
-=======
 Service | Address | User | Password
 :------ |:------|:------:|:--------:
 Jenkins | [http://localhost:8080](http://localhost:8080) | jenkins | jenkins |
-Prometheus | [Prometheus](http://localhost:9090) | None | None |
+Prometheus | [http://localhost:9090](http://localhost:9090) | None | None |

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,5 +2,5 @@ FROM jenkinsci/blueocean
 MAINTAINER Liora Milbaum <liora@lmb.co.il>
 
 ENV JENKINS_ADMIN_USER="jenkins" JENKINS_ADMIN_PASS="jenkins"
-COPY ./scripts/basic-security.groovy ${JENKINS_HOME}/init.groovy.d/basic-security.groovy
+COPY jenkins/scripts/basic-security.groovy ${JENKINS_HOME}/init.groovy.d/basic-security.groovy
 ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -2,7 +2,7 @@
 
 set -euox pipefail
 
-docker build -t dpline/jenkins .
+docker build -t dpline/jenkins -f jenkins/Dockerfile .
 
 [ ! "$(docker ps -a | grep jenkins)" ] &&
 docker run \


### PR DESCRIPTION
Deployment scripts and files use relative path but a user doesn't
deploy jenkins from jenkins directory. It's done from root, using
dpline deployment scripts.